### PR TITLE
update urls

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -3,6 +3,7 @@
   <version>0.4.7</version>
   <description>rqt_shell is a Python GUI plugin providing an interactive shell.</description>
   <maintainer email="scholz@sim.tu-darmstadt.de">Dorian Scholz</maintainer>
+  <maintainer email="kunal_tyagi@yahoo.com">Kunal Tyagi</maintainer>
 
   <license>BSD</license>
 

--- a/package.xml
+++ b/package.xml
@@ -6,9 +6,9 @@
 
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/rqt_shell</url>
-  <url type="repository">https://github.com/ros-visualization/rqt_common_plugins</url>
-  <url type="bugtracker">https://github.com/ros-visualization/rqt_common_plugins/issues</url>
+  <url type="website">http://wiki.ros.org/rqt_shell</url>
+  <url type="repository">https://github.com/ros-visualization/rqt_shell</url>
+  <url type="bugtracker">https://github.com/ros-visualization/rqt_shell/issues</url>
 
   <author>Dorian Scholz</author>
 


### PR DESCRIPTION
With the plugin being split out from `rqt_common_plugins` I will do a last release for Lunar (as well as re-release for Kinetic, Jade, and Indigo) in the next days. After that I will stop watching this repo, not look at issues and pull requests, and not perform new releases.

Someone needs to take over the maintenance role which specifically includes doing new releases. @DorianScholz You are currently listed in the manifest as the maintainer. I am not sure if you want to take this role and fully take over this repository? Or anyone else would like to step up (@kunaltyagi @ablasdel @cottsay @130s since you have contributed to the package in the past)?

Please let me know if you want to be added / removed from the list of maintainers in the manifest. Otherwise I will go ahead and merge this as-is and release the package a last time setting the maintenance status to `unmaintained`.