### PR TITLE
Fix modern setuptools warning about dashes instead of underscores.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rqt_shell
+script_dir=$base/lib/rqt_shell
 [install]
-install-scripts=$base/lib/rqt_shell
+install_scripts=$base/lib/rqt_shell


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>