### PR TITLE
Add in pytest test dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,8 @@
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
 
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <qt_gui plugin="${prefix}/plugin.xml"/>
     <build_type>ament_python</build_type>

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'rqt_shell is a Python GUI plugin providing an interactive shell.'
     ),
     license='BSD',
+    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'rqt_shell = ' + package_name + '.main:main',


### PR DESCRIPTION
While there are no tests today, this configures it so that any new tests will use pytest.